### PR TITLE
Update the curl dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ env_logger = "0.3"
 trust-dns = { version = "0.9.2", default-features = false }
 
 [dev-dependencies]
-curl = "0.3"
+curl = "0.4"


### PR DESCRIPTION
This was preventing the tests from building against OpenSSL 1.1, due to
the obsolete dependency to the openssl crate in version 0.7.

Fixes #5.