### PR TITLE
Switch from deprecated tokio_core::io to tokio_io::io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 log = "0.3"
 futures = "0.1"
 tokio-core = "0.1"
+tokio-io = "0.1"
 env_logger = "0.3"
 trust-dns = { version = "0.9.2", default-features = false }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,10 +40,10 @@
 #[macro_use]
 extern crate log;
 extern crate env_logger;
-#[macro_use]
 extern crate futures;
 #[macro_use]
 extern crate tokio_core;
+extern crate tokio_io;
 extern crate trust_dns;
 
 use std::cell::RefCell;
@@ -57,7 +57,7 @@ use std::time::Duration;
 
 use futures::future;
 use futures::{Future, Stream, Poll, Async};
-use tokio_core::io::{read_exact, write_all, Window};
+use tokio_io::io::{read_exact, write_all, Window};
 use tokio_core::net::{TcpStream, TcpListener};
 use tokio_core::reactor::{Core, Handle, Timeout};
 use trust_dns::client::{ClientFuture, BasicClientHandle, ClientHandle};


### PR DESCRIPTION
Fixes all the warnings that were present on master when using an up to
date tokio-core.